### PR TITLE
fix: 数式番号の左の余白が少ない

### DIFF
--- a/src/components/Article/style.module.scss
+++ b/src/components/Article/style.module.scss
@@ -292,6 +292,10 @@
             flex-grow: 1;
             display: inline-flex;
             justify-content: center;
+
+            & > * {
+              flex-shrink: 0;
+            }
           }
 
           .tag {


### PR DESCRIPTION
Fixes #999