### PR TITLE
fix: DataViewerからコピーした文字列のキーと値の間に改行が入らないようにする

### DIFF
--- a/src/components/DataViewer/style.module.scss
+++ b/src/components/DataViewer/style.module.scss
@@ -10,16 +10,17 @@
   overflow-x: auto;
 
   & > dl {
-    display: grid;
-    grid-template-columns: max-content 1fr;
+    flex-direction: row;
+    white-space: pre-wrap;
+    word-break: break-all;
 
     & > dt {
-      white-space: pre;
+      display: inline;
       color: var(--gjRed9);
     }
 
     & > dd {
-      word-break: break-all;
+      display: inline;
 
       &[title="String"] {
         color: var(--gjRed6);

--- a/src/util/walkValue.ts
+++ b/src/util/walkValue.ts
@@ -78,6 +78,12 @@ const walkObject = function* (
 	if (circularPath) {
 		const text = `[Circular ${circularPath.join(".")}]`;
 		yield { text, value, type: "Circular", path };
+	} else if (typeof value.message === "string" && "stack" in value) {
+		const { stack } = value;
+		if (typeof stack === "string") {
+			yield { text: stack, value, type: getType(value), path };
+			return;
+		}
 	} else {
 		circular.set(value, path);
 		const type = getType(value);


### PR DESCRIPTION
Fixes #1002